### PR TITLE
[NSH-2024] Adds nss as community sponsor

### DIFF
--- a/data/events/2024/nashville/main.yml
+++ b/data/events/2024/nashville/main.yml
@@ -137,8 +137,8 @@ sponsors:
    level: gold
  - id: nashville-data-nerds
    level: community
-#  - id: gitlab
-#    level: gold
+ - id: nss
+   level: community
 #  - id: instana
 #    level: silver
 #  - id: trendmicro


### PR DESCRIPTION
Adds Nashville Software School as a community sponsor